### PR TITLE
raise RuntimeError if the instance name not registered

### DIFF
--- a/src/ec2instances/ec2_instance_mapping.py
+++ b/src/ec2instances/ec2_instance_mapping.py
@@ -72,6 +72,10 @@ class Ec2InstanceMapping(VmInstanceMappingBase[VmInstanceProxy]):
                 },
             ],
         )
+        if not instance_details["Reservations"]:
+            raise RuntimeError(
+            "[ERROR] No such instance registered: wrong instance name provided"
+        )
         return instance_details["Reservations"][0]["Instances"][0]["InstanceId"]
 
 

--- a/src/ec2instances/ec2_instance_mapping.py
+++ b/src/ec2instances/ec2_instance_mapping.py
@@ -74,8 +74,8 @@ class Ec2InstanceMapping(VmInstanceMappingBase[VmInstanceProxy]):
         )
         if not instance_details["Reservations"]:
             raise RuntimeError(
-            "[ERROR] No such instance registered: wrong instance name provided"
-        )
+                "[ERROR] No such instance registered: wrong instance name provided"
+            )
         return instance_details["Reservations"][0]["Instances"][0]["InstanceId"]
 
 


### PR DESCRIPTION
# Change Summary

## Description

raise RuntimeError if the instance name is not registered or no such instance is found.

Related to:
https://github.com/BstLabs/py-clvm/issues/98

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

