### PR TITLE
Issue-38, Raise exception instead of printing info on bad credentials

### DIFF
--- a/src/ec2instances/ec2_instance_mapping.py
+++ b/src/ec2instances/ec2_instance_mapping.py
@@ -27,8 +27,7 @@ class Ec2AllInstancesData:
             if isinstance(auth_callback, FunctionType):
                 auth_callback(**kwargs)
             else:
-                "\n---\nUnexpected authentication behavior. Please examine your credentials.\n"
-                sys.exit(-1)
+                raise
 
     def __iter__(self) -> Iterator:
         yield from self._instances_data

--- a/src/ec2instances/ec2_instance_proxy.py
+++ b/src/ec2instances/ec2_instance_proxy.py
@@ -36,8 +36,7 @@ class Ec2InstanceProxy:
             if isinstance(auth_callback, FunctionType):
                 auth_callback(**kwargs)
             else:
-                "\n---\nUnexpected authentication behavior. Please examine your credentials.\n"
-                sys.exit(-1)
+                raise
 
     def start(self, wait: bool = True) -> None:
         """


### PR DESCRIPTION
Raise exception instead of printing info on bad credentials when auth callback is not passed.
Fixes #38 