### PR TITLE
fix single quotes are omitted on command execution

### DIFF
--- a/src/ec2instances/ec2_instance_proxy.py
+++ b/src/ec2instances/ec2_instance_proxy.py
@@ -115,7 +115,7 @@ class Ec2RemoteShellProxy(Ec2InstanceProxy):
                 "commands": [
                     "#!/bin/bash",
                     f"source /home/{shell_user or self._default_user}/.bashrc",
-                    f"runuser {shell_user or self._default_user} -c '{' && '.join(commands)}'",
+                    f"runuser -u {shell_user or self._default_user} {' && '.join(commands)}",
                 ],
                 **parameters,
             },


### PR DESCRIPTION
# Change Summary
-u flags seems to be safer than -c in our context, removed single quotes wrapping the command.

Fixes #67 

- [x] Bug fix (non-breaking change which fixes an issue)
